### PR TITLE
Prevent IPv6 RA from gateway image

### DIFF
--- a/FILES/etc/config/dhcp
+++ b/FILES/etc/config/dhcp
@@ -1,0 +1,12 @@
+config dhcp 'eth0'
+	option interface 'eth0'
+	option ignore '1'
+	option ra 'disabled'
+	option dhcpv6 'disabled'
+	option ndp 'disabled'
+
+config odhcpd 'odhcpd'
+	option maindhcp '0'
+	option leasefile '/tmp/hosts/odhcpd'
+	option leasetrigger '/usr/sbin/odhcpd-update'
+	option loglevel '4'

--- a/FILES/etc/rc.local
+++ b/FILES/etc/rc.local
@@ -1,4 +1,12 @@
 #!/bin/sh
+if [ -x /etc/init.d/odhcpd ]; then
+    /etc/init.d/odhcpd stop >/dev/null 2>&1
+    /etc/init.d/odhcpd disable >/dev/null 2>&1
+else
+    killall odhcpd >/dev/null 2>&1
+fi
+sysctl -w net.ipv6.conf.all.forwarding=0 >/dev/null 2>&1
+sysctl -w net.ipv6.conf.default.forwarding=0 >/dev/null 2>&1
 if ! grep -q -r eth06 /etc/config/network; then
     killall odhcpd
     sysctl -w net.ipv6.conf.all.disable_ipv6=1

--- a/FILES/usr/bin/ppg.sh
+++ b/FILES/usr/bin/ppg.sh
@@ -683,6 +683,9 @@ reload_gw() {
     else
         log "[OK] ip_forward disable." succ
     fi
+    if sysctl -w net.ipv6.conf.all.forwarding=0 >/dev/null 2>&1 && sysctl -w net.ipv6.conf.default.forwarding=0 >/dev/null 2>&1; then
+        log "[OK] IPv6 forwarding disabled." succ
+    fi
 
     # fake ping
     if sysctl -a 2>&1 | grep -qE "net\.ipv4\.conf\.all\.route_localnet[ =]+1"; then

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -233,7 +233,7 @@ dns2=10.10.10.9
 ```ini
 ip6=auto
 ```
-该配置将会使用`DHCPv6 + SLAAC`获取IPv6地址。  
+该配置将会使用`DHCPv6 + SLAAC`获取IPv6地址，不请求前缀委派，也不会向局域网广播IPv6 RA/DHCPv6。  
 如果需要配置静态IPv6地址，配置示例如下：  
 ```ini
 ip6=240e:3b6:2333:4444:215:5dff:fe0a:e200/64

--- a/remakeiso.sh
+++ b/remakeiso.sh
@@ -200,7 +200,7 @@ config interface 'eth06'
 	option device 'eth0'
 	option proto 'dhcpv6'
 	option reqaddress 'try'
-	option reqprefix 'auto'
+	option reqprefix 'no'
 EOF
   elif [ "$ipv6_mode" = "static" ]; then
     cat >>"$network_config" <<EOF


### PR DESCRIPTION
## 背景

PaoPao GateWay 的 IPv6 功能说明是“仅用于出口”，但在 `ip6=auto` 场景下，镜像会保留 `odhcpd`，并且 DHCPv6 client 会请求前缀委派：

```text
option reqprefix 'auto'
```

这可能导致 PaoPao GateWay 在局域网中表现为 IPv6 router，向 LAN 侧产生 RA/DHCPv6/NDP 相关影响。对于 fake-ip 网关/代理网关场景，这可能干扰主路由的 IPv6 RA 和客户端默认路由选择。

## 修改内容

- 将 ip6=auto 生成的 DHCPv6 配置从请求前缀改为不请求前缀：
    - option reqprefix 'auto' -> option reqprefix 'no'
- 新增 OpenWrt DHCP 配置，显式关闭 eth0 上的：
    - RA
    - DHCPv6
    - NDP
- 启动时停止并禁用 odhcpd
- 启动和 reload 时关闭 IPv6 forwarding
- 更新 README，说明 IPv6 仅作为出口客户端使用，不向局域网广播 IPv6 RA/DHCPv6

## 预期效果

启用 ip6=auto 后，PaoPao GateWay 仍可通过 DHCPv6/SLAAC 获取 IPv6 地址用于出口访问，但不会请求 IPv6 前缀，也不会在局域网中充当IPv6 router。

## 测试

sh -n remakeiso.sh
sh -n FILES/etc/rc.local
sh -n FILES/usr/bin/ppg.sh