### PR TITLE
Accept proxy providers in YAML validation

### DIFF
--- a/FILES/usr/bin/ppg.sh
+++ b/FILES/usr/bin/ppg.sh
@@ -399,6 +399,10 @@ gen_ovpn_hash() {
     fi
 }
 
+yaml_conf_ok() {
+    grep -qE "^(proxies|proxy-providers):" "$1"
+}
+
 get_conf() {
     net_ready
     sleep 1
@@ -520,7 +524,7 @@ get_conf() {
         fi
     fi
     if [ "$down_type" = "yaml" ]; then
-        if grep -q "proxies:" "$file_down_tmp"; then
+        if yaml_conf_ok "$file_down_tmp"; then
             cp "$file_down_tmp" "$file_down"
             if [ -f /www/ppgw.ini ]; then
                 . /www/ppgw.ini
@@ -818,7 +822,7 @@ reload_gw() {
             if [ -z "$subtime" ]; then
                 subtime="1d"
             fi
-            if grep -q "proxies:" "/tmp/ppgw.yaml.down"; then
+            if yaml_conf_ok "/tmp/ppgw.yaml.down"; then
                 log "Sub yaml OK, skip get."
             else
                 get_conf "$suburl" "yaml"


### PR DESCRIPTION
  修复 PPGW 在加载自定义 YAML 配置时对配置有效性的误判。

  当前逻辑只通过是否包含 `proxies:` 来判断 YAML 是否有效，但 Mihomo 支持在顶层使用 `proxy-providers:` 定义代理集合，并在 `proxy-
  groups` 中通过 `use` 引用 provider。这类配置即使没有顶层 `proxies:` 也是有效配置。

  本次修改将 YAML 校验调整为同时接受：

  - 顶层 `proxies:`
  - 顶层 `proxy-providers:`

  这样可以避免仅使用 `proxy-providers` 的配置被误判为拉取失败。